### PR TITLE
프로젝트 관리 - 담당자 선택 작업 및 피드백 반영

### DIFF
--- a/src/app/(afterLogin)/mypage/project/_component/Dropbox.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/Dropbox.tsx
@@ -1,0 +1,71 @@
+import { useState, useRef, useEffect } from "react";
+import { DropboxProps } from "../_types/Task";
+import { SmallUserImgIcon, CaretDownIcon } from "@/components/icons/icons";
+
+const assigneeList: { label: string; value: string }[] = [
+    { label: "선택없음", value: "" },
+    { label: "이서연", value: "manager1" },
+    { label: "홍길동", value: "manager2" },
+    { label: "김철수", value: "manager3" },
+];
+
+const Dropbox = ({ task, index, onSelectAssignee }: DropboxProps) => {
+    const [openDropdownIndex, setOpenDropdownIndex] = useState<number | null>(null);
+    const toggleDropdown = (index: number) => {
+        setOpenDropdownIndex((prev) => (prev === index ? null : index));
+    };
+    
+    const dropBoxRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropBoxRef.current && !dropBoxRef.current.contains(event.target as Node)) {
+                setOpenDropdownIndex(null);
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, []);
+
+    const handleSelect = (index: number, assignee: { label: string; value: string }) => {
+        onSelectAssignee(index, assignee);
+    }
+
+    return (
+        <div ref={dropBoxRef}>
+            {task.isSelectedAssignee ? (
+                <div className="flex justify-start items-center gap-[6px]" onClick={() => toggleDropdown(index)}>
+                    <SmallUserImgIcon />
+                    <span>{task.assignee}</span>
+                </div>
+            ) : (
+                <div className="flex justify-start items-center gap-[6px] text-n600 cursor-pointer" onClick={() => toggleDropdown(index)}>
+                    <span>담당자 선택</span>
+                    <CaretDownIcon />
+                </div>
+            )}
+            {openDropdownIndex === index && (
+                <div className="absolute right-0 z-10">
+                    <ul className="w-[120px] bg-white border rounded shadow text-left">
+                        {assigneeList.map((assignee) => (
+                            <li
+                                key={assignee.value}
+                                className="h-[36px] px-3 py-2 hover:bg-n200 cursor-pointer"
+                                onClick={() => {
+                                    handleSelect(index, assignee);
+                                    setOpenDropdownIndex(null);
+                                }}
+                            >
+                                {assignee.label}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default Dropbox;

--- a/src/app/(afterLogin)/mypage/project/_component/FileModal.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/FileModal.tsx
@@ -20,6 +20,33 @@ const FileModal: React.FC<FileModalProps> = ({ isOpen, onClose }) => {
     const toggleLinkButton = () => setIsLinkType((prev) => !prev);
     const toggleFileButton = () => setIsFileType((prev) => !prev);
 
+    if (!isOpen) return null;
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+            <div className="fixed inset-0 bg-black bg-opacity-50" />
+            <div className="relative w-[420px] shadow-elavation1 bg-white rounded-xl p-6">
+                <div className="flex gap-6">
+                    <h2 className="text-lg leading-6 font-medium mb-2 min-w-80">파일/링크 제출</h2>
+                    <button onClick={onClose}>
+                        <CloseIcon />
+                    </button>
+                </div>
+                <div className={`${isLinkType || isFileType ? "mt-6" : ""} flex flex-col gap-6`}>
+                    <div className="flex flex-col gap-4">
+                        {isLinkType && <LinkInput/> }
+                        {isFileType && <FileInput/> }
+                    </div>
+                    <div className="flex gap-2">
+                        <Button className="flex-1" label="링크 업로드" icLeft={<LinkSimpleIcon />} size="medium" btnType="line" onClick={() => toggleLinkButton()} />
+                        <Button className="flex-1" label="파일 업로드" icLeft={<PlusCircleIcon />} size="medium" btnType="line" onClick={() => toggleFileButton()} />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const LinkInput = () => {
     /** 링크 */
     const linkInputRef = useRef<HTMLInputElement | null>(null);
     const [linkName, setLinkName] = useState("");
@@ -38,6 +65,22 @@ const FileModal: React.FC<FileModalProps> = ({ isOpen, onClose }) => {
             linkInputRef.current.value = "";
         }
     }
+    return(
+        <div className="w-full border border-n300 bg-n75 rounded pt-3 pb-3 pl-4 pr-4 flex items-center justify-between">
+            <input ref={linkInputRef} className="w-[273px] bg-transparent outline-none" type="text" placeholder="링크 입력"/>
+            <div className="flex items-center gap-2">
+                <button onClick={handleCopy}>
+                    <LinkSimpleIcon />
+                </button>
+                <button onClick={handleLinkDelete}>
+                    <p className="text-sm text-n600">삭제</p>
+                </button>
+            </div>
+        </div>
+    );
+}
+
+const FileInput = () => {
     /** 파일 */
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const [fileName, setFileName] = useState("");
@@ -57,60 +100,24 @@ const FileModal: React.FC<FileModalProps> = ({ isOpen, onClose }) => {
         setFile(null);
         setFileName("");
         if (fileInputRef.current) {
-            //이거 안 하면 삭제했다가 같은 파일을 다시 올릴 수 없음 (같은 파일이 다시 선택돼도 값이 변경되지 않았다고 간주)
             fileInputRef.current.value = "";
         }
     };
 
-    if (!isOpen) return null;
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-            <div className="fixed inset-0 bg-black bg-opacity-50" />
-            <div className="relative w-[420px] shadow-elavation1 bg-white rounded-xl p-6">
-                <div className="flex gap-6">
-                    <h2 className="text-lg leading-6 font-medium mb-2 min-w-80">파일/링크 제출</h2>
-                    <button onClick={onClose}>
-                        <CloseIcon />
-                    </button>
-                </div>
-                <div className={`${isLinkType || isFileType ? "mt-6" : ""} flex flex-col gap-6`}>
-                    <div className="flex flex-col gap-4">
-                        {isLinkType && (
-                            <div className="w-full border border-n300 bg-n75 rounded pt-3 pb-3 pl-4 pr-4 flex items-center justify-between">
-                                <input ref={linkInputRef} className="w-[273px] bg-transparent outline-none" type="text" placeholder="링크 입력"/>
-                                <div className="flex items-center gap-2">
-                                    <button onClick={handleCopy}>
-                                        <LinkSimpleIcon />
-                                    </button>
-                                    <button onClick={handleLinkDelete}>
-                                        <p className="text-sm text-n600">삭제</p>
-                                    </button>
-                                </div>
-                            </div>
-                        )}
-                        {isFileType && (
-                            <div className="w-full border border-n300 bg-n75 rounded pt-3 pb-3 pl-4 pr-4 flex items-center justify-between">
-                                <input className="w-[273px] bg-transparent outline-none" type="text" value={fileName} placeholder="파일을 선택하세요" readOnly />
-                                <div className="flex items-center gap-2">
-                                    <button className="w-5 h-5 p-[1px]" onClick={handleFileIconClick}>
-                                        <DownloadSimpleIcon />
-                                    </button>
-                                    <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} />
-                                    <button onClick={handleFileDelete}>
-                                        <p className="text-sm text-n600">삭제</p>
-                                    </button>
-                                </div>
-                            </div>
-                        )}
-                    </div>
-                    <div className="flex gap-2">
-                        <Button className="flex-1" label="링크 업로드" icLeft={<LinkSimpleIcon />} size="medium" btnType="line" onClick={() => toggleLinkButton()} />
-                        <Button className="flex-1" label="파일 업로드" icLeft={<PlusCircleIcon />} size="medium" btnType="line" onClick={() => toggleFileButton()} />
-                    </div>
-                </div>
+        <div className="w-full border border-n300 bg-n75 rounded pt-3 pb-3 pl-4 pr-4 flex items-center justify-between">
+            <input className="w-[273px] bg-transparent outline-none" type="text" value={fileName} placeholder="파일을 선택하세요" readOnly />
+            <div className="flex items-center gap-2">
+                <button className="w-5 h-5 p-[1px]" onClick={handleFileIconClick}>
+                    <DownloadSimpleIcon />
+                </button>
+                <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} />
+                <button onClick={handleFileDelete}>
+                    <p className="text-sm text-n600">삭제</p>
+                </button>
             </div>
         </div>
     );
-};
+}
 
 export default FileModal;

--- a/src/app/(afterLogin)/mypage/project/_component/RightSection.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/RightSection.tsx
@@ -4,42 +4,38 @@ import { useState } from "react";
 import Button from "@/components/Button";
 import { DownloadSimpleIcon, DownloadSimpleIconWhite } from "@/components/icons/icons";
 import Table from "./Table";
-import FileModal from "./FileModal";
+import { Task } from "../_types/Task";
 
 export default function RightSection() {
-    //담당자 드롭박스
-    const [openDropdownIndex, setOpenDropdownIndex] = useState<number | null>(null);
-    const toggleDropdown = (index: number) => {
-        setOpenDropdownIndex((prev) => (prev === index ? null : index));
-    };
-
-    //파일 모달
-    const [openFileModalIndex, setOpenFileModalIndex] = useState<number | null>(null);
-    const openFileModal = (index: number) => {
-        setOpenFileModalIndex(index);
-    };
-
-    //탬플릿 다운로드
-    const onDownloadTemplate = () => {
-        //TODO
-    };
-
-    //일단 하드코딩
-    const tasks = [
+    const [tasks, setTasks] = useState<Task[]>([ //일단 하드코딩
         {
             key: "D_1",
             title: "[디자인] 와이어프레임",
             assignee: "홍길동",
             dueDate: "2025-02-20",
-            submitted: true,
-            isEditable: false,
+            isSelectedAssignee: true,
+            isSelectedDate: true, 
+            isSubmittedFile: true
         },
         {
             key: "D_2",
-            title: "[기획] 회의록 작성",
-            isEditable: true,
+            title: "[기획] 회의록 작성"
         },
-    ];
+    ]);
+    //탬플릿 다운로드
+    const onDownloadTemplate = () => {
+        //TODO
+    };
+
+    const handleSelectAssignee = (index: number, assignee: { label: string; value: string }) => {
+        const updatedTasks = [...tasks];
+        updatedTasks[index] = {
+            ...updatedTasks[index],
+            assignee: assignee.label, 
+            isSelectedAssignee: !(assignee.value === "")
+        };
+        setTasks(updatedTasks);
+    }
 
     return (
         <div className="width-[900px] m-10">
@@ -63,15 +59,13 @@ export default function RightSection() {
                             <Button label="전체 탬플릿" onClick={() => onDownloadTemplate} icLeft={<DownloadSimpleIconWhite />} size="small" btnType="primary" />
                         </div>
                     </div>
-                    <Table tasks={tasks} onToggleAssignee={toggleDropdown} openDropdownIndex={openDropdownIndex} onOpenFileModal={openFileModal}></Table>
+                    <Table tasks={tasks} onSelectAssignee={handleSelectAssignee}></Table>
                 </div>
                 <div className="mt-[40px] flex flex-col">
                     <div className="text-h3 text-n900">선택 과제</div>
                     {/* 테이블 */}
                 </div>
-            </div>
-            {/* 모달 렌더링 부분 */}
-            {openFileModalIndex !== null && <FileModal isOpen={true} onClose={() => setOpenFileModalIndex(null)} />}
+            </div>            
         </div>
     );
 }

--- a/src/app/(afterLogin)/mypage/project/_component/SideMenu.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/SideMenu.tsx
@@ -20,7 +20,7 @@ export default function SideMenu() {
             <div>
                 <div className="flex flex-col gap-4">
                     <Selectbox
-                        placeholder="Selectbox"
+                        placeholder="프로젝트 선택"
                         options={[
                             { value: "1", label: "테스크메이트" },
                             { value: "2", label: "음하하프로젝트" },
@@ -69,9 +69,9 @@ export default function SideMenu() {
                     </span>
                     {isOpen && (
                         <div className="absolute right-0 bottom-full mb-[9px]">
-                            <ul className="w-[120px] bg-white border rounded shadow z-10 text-xs">
-                                <li className="h-[36px] pl-3 pr-3 pt-2 pd-2 hover:bg-n200">프로젝트 탈퇴</li>
-                                <li className="h-[36px] pl-3 pr-3 pt-2 pd-2 hover:bg-n200">프로젝트 삭제</li>
+                            <ul className="w-[120px] bg-white border rounded shadow z-10 text-sm text-n800">
+                                <li className="h-[36px] pl-3 pr-3 pt-2 pd-2 hover:bg-n200 cursor-pointer">프로젝트 탈퇴</li>
+                                <li className="h-[36px] pl-3 pr-3 pt-2 pd-2 hover:bg-n200 cursor-pointer">프로젝트 삭제</li>
                             </ul>
                         </div>
                     )}

--- a/src/app/(afterLogin)/mypage/project/_component/Table.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/Table.tsx
@@ -1,23 +1,15 @@
-interface Task {
-    key: string;
-    title: string;
-    assignee?: string;
-    dueDate?: string;
-    submitted?: boolean;  //제출 완료 여부
-    isEditable?: boolean; //담당자, 마감기한, 제출 수정 시
-}
+import { useState } from "react";
+import { TaskTableProps } from "../_types/Task";
+import { FolderIcon, CalendaBlankIcon, UploadSimpleIcon } from "@/components/icons/icons";
+import Dropbox from "./Dropbox";
+import FileModal from "./FileModal";
 
-interface TaskTableProps {
-    tasks: Task[];
-    onToggleAssignee?: (index: number) => void; //드롭박스 event handler
-    openDropdownIndex?: number | null;          //드롭박스 행 idx
-    onOpenFileModal?: (index: number) => void;  //파일모달 event handler
-}
-
-import { FolderIcon, SmallUserImgIcon, CaretDownIcon, CalendaBlankIcon, UploadSimpleIcon
-} from "@/components/icons/icons";
-
-const Table: React.FC<TaskTableProps> = ({ tasks, onToggleAssignee, openDropdownIndex, onOpenFileModal}) => {
+const Table: React.FC<TaskTableProps> = ({ tasks, onSelectAssignee }) => {
+    //파일 모달
+    const [openFileModalIndex, setOpenFileModalIndex] = useState<number | null>(null);
+    const openFileModal = (index: number) => {
+        setOpenFileModalIndex(index);
+    };
     return (
         <div className="mt-4 rounded border border-n400">
             <table className="w-full text-xs border-separate border-spacing-0">
@@ -35,51 +27,33 @@ const Table: React.FC<TaskTableProps> = ({ tasks, onToggleAssignee, openDropdown
                     {tasks.map((task, index) => (
                         <tr key={task.key} className={`border-t h-[42px] ${index === tasks.length - 1 ? "last-row" : ""}`}>
                             <td className={`p-3 text-center ${index === tasks.length - 1 ? "rounded-bl-xl" : "border-b"}`}>
-                                <input type="checkbox" className="w-4 h-4 border-n400"/>
+                                <input type="checkbox" className="w-4 h-4 border-n400 cursor-pointer" />
                             </td>
                             <td className={`p-3 border-l ${index === tasks.length - 1 ? "" : "border-b"}`}>{task.key}</td>
                             <td className={`p-3 border-l ${index === tasks.length - 1 ? "" : "border-b"}`}>{task.title}</td>
-                            <td className={`relative p-3 border-l text-center ${index === tasks.length - 1 ? "" : "border-b"}`}>
-                                {task.isEditable ? (
-                                    <div className="flex justify-center items-center gap-1 text-n600 cursor-pointer" onClick={() => onToggleAssignee?.(index)}>
-                                        <span>담당자 선택</span>
-                                        <CaretDownIcon />
-                                    </div>
-                                ) : (
-                                    <div className="flex justify-center items-center gap-1">
-                                        <SmallUserImgIcon />
-                                        <span>{task.assignee}</span>
-                                    </div>
-                                )}
-                                {openDropdownIndex === index && (
-                                    <div className="absolute right-0 z-10">
-                                        <ul className="w-[120px] bg-white border rounded shadow text-left">
-                                            <li className="h-[36px] px-3 py-2 hover:bg-n200">이서연</li>
-                                            <li className="h-[36px] px-3 py-2 hover:bg-n200">홍길동</li>
-                                        </ul>
-                                    </div>
-                                )}
+                            <td className={`relative p-3 border-l ${index === tasks.length - 1 ? "" : "border-b"}`}>
+                                <Dropbox task={task} index={index} onSelectAssignee={onSelectAssignee} />
                             </td>
                             <td className={`p-3 text-center border-l ${index === tasks.length - 1 ? "" : "border-b"}`}>
-                                {task.isEditable ? (
+                                {task.isSelectedDate ? (
+                                    task.dueDate
+                                ) : (
                                     <div className="flex justify-center items-center gap-1 text-n600 cursor-pointer">
                                         <CalendaBlankIcon />
                                         <span>기한 설정</span>
                                     </div>
-                                ) : (
-                                    task.dueDate
                                 )}
                             </td>
                             <td className={`p-3 text-center border-l ${index === tasks.length - 1 ? "rounded-br-xl" : "border-b"}`}>
-                                {task.isEditable ? (
-                                    <div className="flex justify-center items-center gap-1 text-n600 cursor-pointer" onClick={() => onOpenFileModal?.(index)}>
-                                        <UploadSimpleIcon />
-                                        <span>제출하기</span>
+                                {task.isSubmittedFile ? (
+                                    <div className="flex justify-center items-center gap-1" onClick={() => openFileModal(index)}>
+                                        <FolderIcon />
+                                        <span>제출완료</span>
                                     </div>
                                 ) : (
-                                    <div className="flex justify-center items-center gap-1">
-                                        <FolderIcon />
-                                        <span>{task.submitted ? "제출완료" : "미제출???"}</span>
+                                    <div className="flex justify-center items-center gap-1 text-n600 cursor-pointer" onClick={() => openFileModal(index)}>
+                                        <UploadSimpleIcon />
+                                        <span>제출하기</span>
                                     </div>
                                 )}
                             </td>
@@ -87,6 +61,8 @@ const Table: React.FC<TaskTableProps> = ({ tasks, onToggleAssignee, openDropdown
                     ))}
                 </tbody>
             </table>
+            {/* 모달 렌더링 부분 */}
+            {openFileModalIndex !== null && <FileModal isOpen={true} onClose={() => setOpenFileModalIndex(null)} />}
         </div>
     );
 };

--- a/src/app/(afterLogin)/mypage/project/_types/Task.tsx
+++ b/src/app/(afterLogin)/mypage/project/_types/Task.tsx
@@ -1,0 +1,21 @@
+export interface Task {
+    key: string;
+    title: string;
+    assignee?: string;
+    dueDate?: string;
+    file?: string;
+    isSelectedAssignee?: boolean;
+    isSelectedDate?: boolean;
+    isSubmittedFile?: boolean;
+}
+
+export interface TaskTableProps {
+    tasks: Task[];
+    onSelectAssignee: (index: number, assignee: { label: string; value: string }) => void;
+}
+
+export interface DropboxProps {
+    task: Task;
+    index: number;
+    onSelectAssignee: (index: number, assignee: { label: string; value: string }) => void;
+}


### PR DESCRIPTION
## 📖 관련 문서

## ✍🏻 변경사항

-   유지보수성을 높이기 위해 컴포넌트들을 분리했습니다 ex) dropbox, fileinput, linkinput
-   지난 pr 리뷰의 피드백들을 반영했습니다. #62 

## 📝 Issue Number

-  #52 

## 🔍 확인할 목록

- 현재 rightsection에서 tasks 정보를 관리하면서 dropbox에서 담당자를 선택 시, 이벤트가 dropbox -> table -> rightsection으로 보내지는데 이 부분 괜찮은지 확인 부탁드립니다 !
+ rightsection에서 task를 관리하려한 이유는 나중에 탬플릿을 다운받을 때 task의 file 정보가 필요할 듯 해서 입니다..! 
