### PR TITLE
프로젝트 관리 - 프로세스의 체크박스

### DIFF
--- a/src/app/(afterLogin)/mypage/project/_component/Table.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/Table.tsx
@@ -1,10 +1,17 @@
 import { useState } from "react";
 import { TaskTableProps } from "../_types/Task";
 import { FolderIcon, CalendaBlankIcon, UploadSimpleIcon } from "@/components/icons/icons";
+import Checkbox from "@/components/Checkbox";
 import Dropbox from "./Dropbox";
 import FileModal from "./FileModal";
 
-const Table: React.FC<TaskTableProps> = ({ tasks, onSelectAssignee }) => {
+const Table: React.FC<TaskTableProps> = ({ tasks, onSelectAssignee, checkedIds = [], onCheck }) => {
+    //체크박스
+    const handleCheckBox = (key: string) => {
+        const next = checkedIds.includes(key) ? checkedIds.filter((i) => i !== key) : [...checkedIds, key];
+        onCheck(next); //상태는 비동기라 이렇게 해야 함.
+    };
+
     //파일 모달
     const [openFileModalIndex, setOpenFileModalIndex] = useState<number | null>(null);
     const openFileModal = (index: number) => {
@@ -15,7 +22,10 @@ const Table: React.FC<TaskTableProps> = ({ tasks, onSelectAssignee }) => {
             <table className="w-full text-xs border-separate border-spacing-0">
                 <thead className="bg-n50 text-center text-xsEmphasis">
                     <tr className="h-[42px]">
-                        <th className="border-b pt-3 pb-3 rounded-tl-xl w-[64px]">선택</th>
+                        <th className="border-b pt-3 pb-3 rounded-tl-xl w-[64px]">
+                            선택
+                            {/* checkbox 전체 선택/전체 해제 필요할 수도 */}
+                        </th>
                         <th className="border-b pt-3 pb-3 w-[74px]">Key</th>
                         <th className="border-b pt-3 pb-3 w-[243px]">과제</th>
                         <th className="border-b pt-3 pb-3 w-[120px]">담당자</th>
@@ -27,7 +37,7 @@ const Table: React.FC<TaskTableProps> = ({ tasks, onSelectAssignee }) => {
                     {tasks.map((task, index) => (
                         <tr key={task.key} className={`border-t h-[42px] ${index === tasks.length - 1 ? "last-row" : ""}`}>
                             <td className={`p-3 text-center ${index === tasks.length - 1 ? "rounded-bl-xl" : "border-b"}`}>
-                                <input type="checkbox" className="w-4 h-4 border-n400 cursor-pointer" />
+                                <Checkbox checked={checkedIds.includes(task.key)} value="1" onClick={() => handleCheckBox(task.key)} />
                             </td>
                             <td className={`p-3 border-l ${index === tasks.length - 1 ? "" : "border-b"}`}>{task.key}</td>
                             <td className={`p-3 border-l ${index === tasks.length - 1 ? "" : "border-b"}`}>{task.title}</td>

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/TaskSection.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/TaskSection.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+
+/** 일단 보류 => 필수,선택을 별도로 나눠서 쓸 필요가 있을까.. */
+import React, {useState} from "react";
 import Button from "@/components/Button";
 import { DownloadSimpleIcon, DownloadSimpleIconWhite } from "@/components/icons/icons";
 import Table from "../Table";
@@ -9,10 +11,11 @@ interface TaskSectionProps {
     tasks: Task[];
     onDownloadTemplate: () => void;
     onSelectAssignee: (index: number, assignee: { label: string; value: string }) => void;
+    onCheck: (indexs: string[]) => void;
     isRequired?: boolean;
 }
 
-export default function TaskSection({ title, tasks, onDownloadTemplate, onSelectAssignee, isRequired = false }: TaskSectionProps) {
+export default function TaskSection({ title, tasks, onDownloadTemplate, onSelectAssignee, onCheck, isRequired = false }: TaskSectionProps) {
     return (
         <div className="mt-[40px] flex flex-col">
             <div className="flex justify-between items-end">
@@ -34,7 +37,7 @@ export default function TaskSection({ title, tasks, onDownloadTemplate, onSelect
                     </div>
                 )}
             </div>
-            <Table tasks={tasks} onSelectAssignee={onSelectAssignee} />
+            {/* <Table tasks={tasks} onSelectAssignee={onSelectAssignee} checkedIds={} onCheck={onCheck}/> */}
         </div>
     );
 }

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Complete.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Complete.tsx
@@ -1,15 +1,26 @@
 "use client";
 
 import React, { useState } from "react";
-import TaskSection from "../TaskSection";
 import { Task } from "../../../_types/Task";
+import Button from "@/components/Button";
+import { DownloadSimpleIcon, DownloadSimpleIconWhite } from "@/components/icons/icons";
+import Table from "../../Table";
 
 export default function Complete() {
     const [requiredTasks, setRequiredTasks] = useState<Task[]>([{ key: "C_1", title: "프로젝트 결과물" }]);
     const [optionalTasks, setOptionalTasks] = useState<Task[]>([{ key: "C_2", title: "프로젝트 회고" }]);
 
+    const [checkedIds, setCheckedIds] = useState<string[]>([]);
+    const handleCheckedIdsFromTable = (checkedFromTable: string[], tableTasks: Task[]) => {
+        const tableKeys = tableTasks.map((task) => task.key);
+        setCheckedIds((prev) => [...prev.filter((id) => !tableKeys.includes(id)), ...checkedFromTable]);
+    };
     const onDownloadTemplate = () => {
-        // TODO: 템플릿 다운로드 로직
+        const selectedTasks = [...requiredTasks, ...optionalTasks].filter((task) => checkedIds.includes(task.key));
+        if (selectedTasks.length === 0) {
+            alert("선택된 항목이 없습니다.");
+            return;
+        }
     };
 
     const handleSelectAssignee = (type: "required" | "optional", index: number, assignee: { label: string; value: string }) => {
@@ -33,20 +44,44 @@ export default function Complete() {
     return (
         <div className="p-10">
             <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">완료</div>
-            <TaskSection
-                title="필수 과제"
-                tasks={requiredTasks}
-                onDownloadTemplate={onDownloadTemplate}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
-                isRequired={true}
-            />
-            <TaskSection
-                title="선택 과제"
-                tasks={optionalTasks}
-                onDownloadTemplate={() => {}}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
-                isRequired={false}
-            />
+
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">필수 과제</div>
+                    <div className="flex gap-2">
+                        <Button
+                            label="선택 탬플릿"
+                            onClick={onDownloadTemplate}
+                            icLeft={
+                                <div className="w-3 h-3">
+                                    <DownloadSimpleIcon />
+                                </div>
+                            }
+                            size="small"
+                            btnType="line"
+                        />
+                        <Button label="전체 탬플릿" onClick={onDownloadTemplate} icLeft={<DownloadSimpleIconWhite />} size="small" btnType="primary" />
+                    </div>
+                </div>
+                <Table
+                    tasks={requiredTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, requiredTasks)}
+                />
+            </div>
+
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">선택 과제</div>
+                </div>
+                <Table
+                    tasks={optionalTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, optionalTasks)}
+                />
+            </div>
         </div>
     );
 }

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Design.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Design.tsx
@@ -1,19 +1,10 @@
-/**
-[필수 과제]
-- 디자인 시스템
-- 디자인 파일 or URL
-
-[선택 과제]
-- 테스트 계획서
-- 시스템 설계도
-- 사용자 설정
- */
-
 "use client";
 
 import React, { useState } from "react";
-import TaskSection from "../TaskSection";
 import { Task } from "../../../_types/Task";
+import Button from "@/components/Button";
+import { DownloadSimpleIcon, DownloadSimpleIconWhite } from "@/components/icons/icons";
+import Table from "../../Table";
 
 export default function Design() {
     const [requiredTasks, setRequiredTasks] = useState<Task[]>([
@@ -47,8 +38,17 @@ export default function Design() {
         },
     ]);
 
+    const [checkedIds, setCheckedIds] = useState<string[]>([]);
+    const handleCheckedIdsFromTable = (checkedFromTable: string[], tableTasks: Task[]) => {
+        const tableKeys = tableTasks.map((task) => task.key);
+        setCheckedIds((prev) => [...prev.filter((id) => !tableKeys.includes(id)), ...checkedFromTable]);
+    };
     const onDownloadTemplate = () => {
-        // TODO: 템플릿 다운로드 로직
+        const selectedTasks = [...requiredTasks, ...optionalTasks].filter((task) => checkedIds.includes(task.key));
+        if (selectedTasks.length === 0) {
+            alert("선택된 항목이 없습니다.");
+            return;
+        }
     };
 
     const handleSelectAssignee = (type: "required" | "optional", index: number, assignee: { label: string; value: string }) => {
@@ -72,19 +72,44 @@ export default function Design() {
     return (
         <div className="p-10">
             <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">디자인</div>
-            <TaskSection 
-                title="필수 과제"
-                tasks={requiredTasks}
-                onDownloadTemplate={onDownloadTemplate} 
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)} 
-                isRequired={true} />
-            <TaskSection
-                title="선택 과제"
-                tasks={optionalTasks}
-                onDownloadTemplate={() => {}}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
-                isRequired={false}
-            />
+
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">필수 과제</div>
+                    <div className="flex gap-2">
+                        <Button
+                            label="선택 탬플릿"
+                            onClick={onDownloadTemplate}
+                            icLeft={
+                                <div className="w-3 h-3">
+                                    <DownloadSimpleIcon />
+                                </div>
+                            }
+                            size="small"
+                            btnType="line"
+                        />
+                        <Button label="전체 탬플릿" onClick={onDownloadTemplate} icLeft={<DownloadSimpleIconWhite />} size="small" btnType="primary" />
+                    </div>
+                </div>
+                <Table
+                    tasks={requiredTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, requiredTasks)}
+                />
+            </div>
+
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">선택 과제</div>
+                </div>
+                <Table
+                    tasks={optionalTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, optionalTasks)}
+                />
+            </div>
         </div>
     );
 }

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Develop.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Develop.tsx
@@ -52,7 +52,7 @@ export default function Develop() {
 
     return (
         <div className="p-10">
-            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">디자인</div>
+            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">개발</div>
 
             <div className="mt-[40px] flex flex-col">
                 <div className="flex justify-between items-end">

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Develop.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Develop.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React, { useState } from "react";
-import TaskSection from "../TaskSection";
 import { Task } from "../../../_types/Task";
+import Button from "@/components/Button";
+import { DownloadSimpleIcon, DownloadSimpleIconWhite } from "@/components/icons/icons";
+import Table from "../../Table";
 
 export default function Develop() {
     const [requiredTasks, setRequiredTasks] = useState<Task[]>([
@@ -17,8 +19,17 @@ export default function Develop() {
         { key: "DEV_6", title: "사용자 설정" },
     ]);
 
+    const [checkedIds, setCheckedIds] = useState<string[]>([]);
+    const handleCheckedIdsFromTable = (checkedFromTable: string[], tableTasks: Task[]) => {
+        const tableKeys = tableTasks.map((task) => task.key);
+        setCheckedIds((prev) => [...prev.filter((id) => !tableKeys.includes(id)), ...checkedFromTable]);
+    };
     const onDownloadTemplate = () => {
-        // TODO: 템플릿 다운로드 로직
+        const selectedTasks = [...requiredTasks, ...optionalTasks].filter((task) => checkedIds.includes(task.key));
+        if (selectedTasks.length === 0) {
+            alert("선택된 항목이 없습니다.");
+            return;
+        }
     };
 
     const handleSelectAssignee = (type: "required" | "optional", index: number, assignee: { label: string; value: string }) => {
@@ -41,21 +52,44 @@ export default function Develop() {
 
     return (
         <div className="p-10">
-            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">개발</div>
-            <TaskSection
-                title="필수 과제"
-                tasks={requiredTasks}
-                onDownloadTemplate={onDownloadTemplate}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
-                isRequired={true}
-            />
-            <TaskSection
-                title="선택 과제"
-                tasks={optionalTasks}
-                onDownloadTemplate={() => {}}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
-                isRequired={false}
-            />
+            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">디자인</div>
+
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">필수 과제</div>
+                    <div className="flex gap-2">
+                        <Button
+                            label="선택 탬플릿"
+                            onClick={onDownloadTemplate}
+                            icLeft={
+                                <div className="w-3 h-3">
+                                    <DownloadSimpleIcon />
+                                </div>
+                            }
+                            size="small"
+                            btnType="line"
+                        />
+                        <Button label="전체 탬플릿" onClick={onDownloadTemplate} icLeft={<DownloadSimpleIconWhite />} size="small" btnType="primary" />
+                    </div>
+                </div>
+                <Table
+                    tasks={requiredTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, requiredTasks)}
+                />
+            </div>
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">선택 과제</div>
+                </div>
+                <Table
+                    tasks={optionalTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, optionalTasks)}
+                />
+            </div>
         </div>
     );
 }

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Plan.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Plan.tsx
@@ -60,7 +60,7 @@ export default function Plan() {
 
     return (
         <div className="p-10">
-            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">디자인</div>
+            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">기획</div>
 
             <div className="mt-[40px] flex flex-col">
                 <div className="flex justify-between items-end">

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Plan.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Plan.tsx
@@ -1,26 +1,10 @@
-/**
- * [필수 과제]
-- 프로젝트 제목(주제)
-- 프로젝트 개요 문서(프로젝트 목표, 문제 정의 등)
-- 요구사항 정의서
-- WBS
-- WireFrame
-- Convention
-- 화면정의서
-
-[선택 과제]
-- Flow Chart
-- 사용자 페르소나
-- 유스케이스 시나리오
-- 유사 서비스 분석 자료
-- 정보 구조도
-- 사용자 설정
- */
 "use client";
 
 import React, { useState } from "react";
-import TaskSection from "../TaskSection";
 import { Task } from "../../../_types/Task";
+import Button from "@/components/Button";
+import { DownloadSimpleIcon, DownloadSimpleIconWhite } from "@/components/icons/icons";
+import Table from "../../Table";
 
 export default function Plan() {
     const [requiredTasks, setRequiredTasks] = useState<Task[]>([
@@ -42,8 +26,18 @@ export default function Plan() {
         { key: "P_13", title: "사용자 설정" },
     ]);
 
+    const [checkedIds, setCheckedIds] = useState<string[]>([]);
+    const handleCheckedIdsFromTable = (checkedFromTable: string[], tableTasks: Task[]) => {
+        const tableKeys = tableTasks.map((task) => task.key);
+        setCheckedIds((prev) => [...prev.filter((id) => !tableKeys.includes(id)), ...checkedFromTable]);
+    };
     const onDownloadTemplate = () => {
-        // TODO: 템플릿 다운로드 로직
+        const selectedTasks = [...requiredTasks, ...optionalTasks].filter((task) => checkedIds.includes(task.key));
+        console.log('selectedTasks :: ', selectedTasks);
+        if (selectedTasks.length === 0) {
+            alert("선택된 항목이 없습니다.");
+            return;
+        }
     };
 
     const handleSelectAssignee = (type: "required" | "optional", index: number, assignee: { label: string; value: string }) => {
@@ -66,21 +60,44 @@ export default function Plan() {
 
     return (
         <div className="p-10">
-            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">기획</div>
-            <TaskSection
-                title="필수 과제"
-                tasks={requiredTasks}
-                onDownloadTemplate={onDownloadTemplate}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
-                isRequired={true}
-            />
-            <TaskSection
-                title="선택 과제"
-                tasks={optionalTasks}
-                onDownloadTemplate={() => {}}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
-                isRequired={false}
-            />
+            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">디자인</div>
+
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">필수 과제</div>
+                    <div className="flex gap-2">
+                        <Button
+                            label="선택 탬플릿"
+                            onClick={onDownloadTemplate}
+                            icLeft={
+                                <div className="w-3 h-3">
+                                    <DownloadSimpleIcon />
+                                </div>
+                            }
+                            size="small"
+                            btnType="line"
+                        />
+                        <Button label="전체 탬플릿" onClick={onDownloadTemplate} icLeft={<DownloadSimpleIconWhite />} size="small" btnType="primary" />
+                    </div>
+                </div>
+                <Table
+                    tasks={requiredTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, requiredTasks)}
+                />
+            </div>
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">선택 과제</div>
+                </div>
+                <Table
+                    tasks={optionalTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, optionalTasks)}
+                />
+            </div>
         </div>
     );
 }

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Release.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Release.tsx
@@ -1,14 +1,27 @@
 "use client";
 
 import React, { useState } from "react";
-import TaskSection from "../TaskSection";
 import { Task } from "../../../_types/Task";
+import Button from "@/components/Button";
+import { DownloadSimpleIcon, DownloadSimpleIconWhite } from "@/components/icons/icons";
+import Table from "../../Table";
+
 
 export default function Release() {
     const [requiredTasks, setRequiredTasks] = useState<Task[]>([{ key: "R_1", title: "배포 환경 구성 문서" }]);
     const [optionalTasks, setOptionalTasks] = useState<Task[]>([{ key: "R_2", title: "사용자 설정" }]);
+
+    const [checkedIds, setCheckedIds] = useState<string[]>([]);
+    const handleCheckedIdsFromTable = (checkedFromTable: string[], tableTasks: Task[]) => {
+        const tableKeys = tableTasks.map((task) => task.key);
+        setCheckedIds((prev) => [...prev.filter((id) => !tableKeys.includes(id)), ...checkedFromTable]);
+    };
     const onDownloadTemplate = () => {
-        // TODO: 템플릿 다운로드 로직
+        const selectedTasks = [...requiredTasks, ...optionalTasks].filter((task) => checkedIds.includes(task.key));
+        if (selectedTasks.length === 0) {
+            alert("선택된 항목이 없습니다.");
+            return;
+        }
     };
 
     const handleSelectAssignee = (type: "required" | "optional", index: number, assignee: { label: string; value: string }) => {
@@ -31,21 +44,45 @@ export default function Release() {
 
     return (
         <div className="p-10">
-            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">배포</div>
-            <TaskSection
-                title="필수 과제"
-                tasks={requiredTasks}
-                onDownloadTemplate={onDownloadTemplate}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
-                isRequired={true}
-            />
-            <TaskSection
-                title="선택 과제"
-                tasks={optionalTasks}
-                onDownloadTemplate={() => {}}
-                onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
-                isRequired={false}
-            />
+            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">디자인</div>
+
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">필수 과제</div>
+                    <div className="flex gap-2">
+                        <Button
+                            label="선택 탬플릿"
+                            onClick={onDownloadTemplate}
+                            icLeft={
+                                <div className="w-3 h-3">
+                                    <DownloadSimpleIcon />
+                                </div>
+                            }
+                            size="small"
+                            btnType="line"
+                        />
+                        <Button label="전체 탬플릿" onClick={onDownloadTemplate} icLeft={<DownloadSimpleIconWhite />} size="small" btnType="primary" />
+                    </div>
+                </div>
+                <Table
+                    tasks={requiredTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("required", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, requiredTasks)}
+                />
+            </div>
+
+            <div className="mt-[40px] flex flex-col">
+                <div className="flex justify-between items-end">
+                    <div className="text-h3 text-n900">선택 과제</div>
+                </div>
+                <Table
+                    tasks={optionalTasks}
+                    onSelectAssignee={(index, assignee) => handleSelectAssignee("optional", index, assignee)}
+                    checkedIds={checkedIds}
+                    onCheck={(ids) => handleCheckedIdsFromTable(ids, optionalTasks)}
+                />
+            </div>
         </div>
     );
 }

--- a/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Release.tsx
+++ b/src/app/(afterLogin)/mypage/project/_component/rightSection/process/Release.tsx
@@ -44,7 +44,7 @@ export default function Release() {
 
     return (
         <div className="p-10">
-            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">디자인</div>
+            <div className="text-h2 text-n900 left-0 pb-[16px] border-b-[1px] border-n400">배포</div>
 
             <div className="mt-[40px] flex flex-col">
                 <div className="flex justify-between items-end">

--- a/src/app/(afterLogin)/mypage/project/_types/Task.ts
+++ b/src/app/(afterLogin)/mypage/project/_types/Task.ts
@@ -12,6 +12,8 @@ export interface Task {
 export interface TaskTableProps {
     tasks: Task[];
     onSelectAssignee: (index: number, assignee: { label: string; value: string }) => void;
+    checkedIds: string[];
+    onCheck: (indexs: string[]) => void;
 }
 
 export interface DropboxProps {


### PR DESCRIPTION
## 📖 관련 문서

- 프로세스 관리 피그마

## ✍🏻 변경사항

- 공통 checkbox로 변경
- 서로 다른 테이블(필수테이블, 선택테이블)에 있지만 unique key 값이 존재한다고 가정하고, 
선택한 id 값들을 탬플릿 다운로드 시 사용할 수 있게 함.
- TaskSection 컴포넌트 보류 (필수/선택 과제 section을 나눌 필요가 없다고 생각해서 없앨 예정) 
 
## 📝 Issue Number

- #52 

## 🔍 확인할 목록

-  디자인 상, 버튼이 선택/전체 다운로드 2개의 버튼이 있는데, 체크박스로 전체 선택/해제 한다면, 버튼을 템플릿 다운로드 하나로 통일해도 될 것 같습니다! 이 부분은 협의 후 수정하겠습니다.